### PR TITLE
Fix: bistreams not correctly added during import

### DIFF
--- a/dspyce/Item.py
+++ b/dspyce/Item.py
@@ -174,10 +174,11 @@ class Item(DSpaceObject):
             obj_str += '\n\tRelations:'
             for r in self.relations:
                 obj_str += f'\n\t\t{r}'
-        if len(self.contents) > 0:
+        if len(self.bundles) > 0:
             obj_str += '\n\tBitstreams:'
-            for c in self.contents:
-                obj_str += f'\n\t\t{c}'
+            for b in self.bundles:
+                for c in b.bitstreams:
+                    obj_str += f'\n\t\t{c}'
         if len(self.collections) > 0:
             obj_str += '\n\tCollections:'
             for c in self.collections:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dspyce"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
     {name="Löhden, Eike Martin"}
 ]


### PR DESCRIPTION
Small bugfix: bitstreams are currently not added correctly to the Item class when exported via rest. This PR should fix this.