### PR TITLE
Enable multi-threading in the rest-api module

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -24,5 +24,5 @@ keywords:
   - metadata
 license: MIT
 commit: 57b6fc8
-version: ' dspyce-v0.0.5'
+version: ' dspyce-v0.0.6'
 date-released: '2024-09-30'

--- a/README.md
+++ b/README.md
@@ -19,11 +19,6 @@ The **dspyce** packages contains the following classes and packages.
 3. [saf](https://github.com/dspace-unimr/dspyce/tree/main/dspyce/rest) -> The saf packages helps you to create saf packages based on given DSpaceObject objects.
 4. [rest](https://github.com/dspace-unimr/dspyce/tree/main/dspyce/saf) -> The rest packages handles the communication with the RestAPI of a given DSpace instance.
 
-### UML-Diagramm:
-
-The following class diagramm is the basis of the package:
-
-![dspyce.svg](https://raw.githubusercontent.com/dspace-unimr/dspyce/main/docs/uml_diagramm.svg)
 
 ## Requirements
 Requirements are defined in [requirements.txt](https://github.com/dspace-unimr/dspyce/blob/main/requirements.txt), to use the package a python
@@ -32,4 +27,3 @@ version >= 3.10 is necessary.
 ```shell
 pip install -r requirements.txt
 ```
-

--- a/dspyce/_testing/itemTests.py
+++ b/dspyce/_testing/itemTests.py
@@ -5,6 +5,10 @@ from dspyce.bitstreams import Bundle
 
 
 class ItemTest(unittest.TestCase):
+    """
+    Test class for the item class.
+    """
+
     item: ds.Item = ds.Item('xyz', '123456789/1', 'test', ds.Collection('abc'))
 
     def test_entity(self):

--- a/dspyce/_testing/metadataTests.py
+++ b/dspyce/_testing/metadataTests.py
@@ -45,6 +45,9 @@ class MetadataTest(unittest.TestCase):
         self.assertEqual({'value': 'Hello World', 'language': 'en'}, dict(self.mdValue))
 
     def test_pop_value(self):
+        """
+        Test the pop method from MetaData class.
+        """
         obj = md.MetaData({'dc.title': [md.MetaDataValue('Hello World', 'en')]})
         self.assertEqual(md.MetaDataValue('Hello World', 'en'), obj['dc.title'][0])
         obj.pop('dc.title')

--- a/dspyce/_testing/safTest.py
+++ b/dspyce/_testing/safTest.py
@@ -1,13 +1,21 @@
 import logging
+import os
 import unittest
+
 from dspyce import saf
 from dspyce import Item, Collection
 from dspyce.metadata import MetaDataValue
-import os
 
 
 class SAFTest(unittest.TestCase):
+    """
+    Test class for saf module.
+    """
+
     def test_saf(self):
+        """
+        Test method for saf package.
+        """
         saf.saf_write.LOG_LEVEL = logging.DEBUG
         created_dir = False
         if 'test_data' not in os.listdir():
@@ -40,10 +48,10 @@ class SAFTest(unittest.TestCase):
         for file in os.listdir('./test_data/archive_directory/item_0'):
             logging.debug(f'Remove file: ./test_data/archive_directory/item_0/{file}')
             os.remove(f'./test_data/archive_directory/item_0/{file}')
-        os.rmdir(f'./test_data/archive_directory/item_0')
-        logging.debug(f'Remove directory: ./test_data/archive_directory/item_0')
-        os.rmdir(f'./test_data/archive_directory')
-        logging.debug(f'Remove directory: ./test_data/archive_directory')
+        os.rmdir('./test_data/archive_directory/item_0')
+        logging.debug('Remove directory: ./test_data/archive_directory/item_0')
+        os.rmdir('./test_data/archive_directory')
+        logging.debug('Remove directory: ./test_data/archive_directory')
         if created_dir:
             os.rmdir('./test_data')
-            logging.debug(f'Remove directory: ./test_data')
+            logging.debug('Remove directory: ./test_data')

--- a/dspyce/entities/models.py
+++ b/dspyce/entities/models.py
@@ -156,7 +156,7 @@ def from_rest_api(url: str) -> EntityModell:
         raise ValueError(f'No entity types found in instance "{url}"')
     em = EntityModell()
     [em.add_entity(e['label']) for e in entity_objects]
-    relations = rest.get_paginated_objects(f'core/relationshiptypes', 'relationshiptypes')
+    relations = rest.get_paginated_objects('core/relationshiptypes', 'relationshiptypes')
     for r in relations:
         leftward_type = r['leftwardType']
         rightward_type = r['rightwardType']

--- a/dspyce/metadata/models.py
+++ b/dspyce/metadata/models.py
@@ -72,8 +72,7 @@ class MetaData(dict):
         """
         if re.search(r'^[a-zA-Z0-9\-]+\.[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)?$', tag):
             return True
-        else:
-            return False
+        return False
 
     def __setitem__(self, key: str, value: MetaDataValue | list[MetaDataValue]):
         """

--- a/dspyce/rest/RestAPI.py
+++ b/dspyce/rest/RestAPI.py
@@ -1,8 +1,8 @@
+from concurrent.futures import ThreadPoolExecutor
 import json
 import logging
 import requests
 import requests.adapters
-from concurrent.futures import ThreadPoolExecutor
 from requests.exceptions import InvalidJSONError
 
 from ..DSpaceObject import DSpaceObject

--- a/dspyce/rest/RestAPI.py
+++ b/dspyce/rest/RestAPI.py
@@ -180,8 +180,11 @@ class RestAPI:
         :param workers: The number of worker threads to use.
         """
         self.workers = workers
+        logging.debug('Initializing with %i workers.' % workers)
         if self.workers > requests.adapters.DEFAULT_POOLSIZE:
             adapter = requests.adapters.HTTPAdapter(pool_maxsize=self.workers)
+            logging.info('The number of workers (%i) exceeds the number of default connections. '
+                         'Increasing the number of default connections.' % workers)
             self.session.mount(self.api_endpoint, adapter)
 
     def authenticate_api(self) -> bool:

--- a/dspyce/rest/RestAPI.py
+++ b/dspyce/rest/RestAPI.py
@@ -285,7 +285,7 @@ class RestAPI:
             return json_resp
 
         if resp.status_code == 204:
-            operation = [int((i["op"] if "op" in i.keys() else '') == "remove") - 1 for i in json_data]
+            operation = [int((i['op'] if 'op' in i.keys() else '') == 'remove') - 1 for i in json_data]
             if sum(operation) == 0:
                 logging.info('Successfully deleted objects.')
                 return None
@@ -639,7 +639,7 @@ class RestAPI:
             logging.error(f'Problems with parsing paginated object list. A Key-Error occurred.\n{endpoint_json}')
             raise e
         if page == -1:
-            page_info = endpoint_json["page"]
+            page_info = endpoint_json['page']
             if self.workers == 0:
                 for p in range(1, page_info['totalPages']):
                     object_list += self.get_paginated_objects(endpoint, object_key, query_params, p, size)
@@ -695,8 +695,8 @@ class RestAPI:
         :return: The list of Bundle objects.
         """
         bundle_json = self.get_paginated_objects(f'/core/items/{item_uuid}/bundles', 'bundles')
-        bundles = [Bundle(b["name"],
-                          b['dc.description'][0]['value'] if 'dc.description' in b["metadata"].keys() else '',
+        bundles = [Bundle(b['name'],
+                          b['metadata']['dc.description'][0]['value'] if 'dc.description' in b['metadata'].keys() else '',
                           b['uuid']) for b in bundle_json]
         if not include_bitstreams:
             return bundles
@@ -1035,19 +1035,19 @@ class RestAPI:
                 rank = ''
                 if isinstance(metadata[k], dict):
                     metadata[k]: dict
-                    rank = f'/{metadata[k]["position"]}' if "position" in metadata[k].keys() else ''
+                    rank = f'/{metadata[k]["position"]}' if 'position' in metadata[k].keys() else ''
                     rank = f'/{position}' if rank == '' and str(position) != '-1' else rank
-                    values = {"value": metadata[k]["value"]}
-                    if "language" in metadata[k].keys():
-                        values.update({"language": metadata[k]["language"]})
-                patch_json.append({"op": operation, "path": f"/metadata/{k}" + rank, "value": values})
+                    values = {'value': metadata[k]['value']}
+                    if 'language' in metadata[k].keys():
+                        values.update({'language': metadata[k]['language']})
+                patch_json.append({'op': operation, 'path': f'/metadata/{k}' + rank, 'value': values})
         else:
             for k in metadata.keys():
                 rank = [i['position'] for i in metadata[k]]
                 if len(rank) > 0:
-                    patch_json += [{"op": operation, "path": f"/metadata/{k}/{r}"} for r in rank]
+                    patch_json += [{'op': operation, 'path': f'/metadata/{k}/{r}'} for r in rank]
                 else:
-                    patch_json.append({"op": operation, "path": f"/metadata/{k}" +
+                    patch_json.append({'op': operation, 'path': f'/metadata/{k}' +
                                                                 (f'/{position}' if str(position) != '-1' else '')})
 
         url = 'core/' + (f'{obj_type}s' if obj_type in ('item', 'collection') else 'communities')
@@ -1136,8 +1136,8 @@ class RestAPI:
         :param bitstream_uuid: The uuid of the bitstream to delete
         """
         bitstream_uuid = [bitstream_uuid] if isinstance(bitstream_uuid, str) else bitstream_uuid
-        patch_call = [{"op": "remove", "path": f"/bitstreams/{uuid}"} for uuid in bitstream_uuid]
-        self.patch_api("core/bitstreams", patch_call)
+        patch_call = [{'op': 'remove', 'path': f'/bitstreams/{uuid}'} for uuid in bitstream_uuid]
+        self.patch_api('core/bitstreams', patch_call)
         logging.info(f'Successfully deleted bitstream with uuid "{bitstream_uuid}".')
 
     def delete_bundles(self, bundle_uuid: str | list[str], include_bitstreams: bool = False):

--- a/dspyce/rest/console.py
+++ b/dspyce/rest/console.py
@@ -1,7 +1,7 @@
 from getpass import getpass
-from .RestAPI import RestAPI
-import requests
 import logging
+import requests
+from .RestAPI import RestAPI
 
 
 def authenticate_to_rest(rest_api: str, user: str = None, log_level=logging.INFO, log_file: str = None) -> RestAPI:

--- a/dspyce/saf/saf_write.py
+++ b/dspyce/saf/saf_write.py
@@ -155,7 +155,7 @@ def create_saf_package(item: Item, element_id: int, path: str, overwrite: bool =
     xml_files = export_schemas(item.metadata)
     for file_name in xml_files.keys():
         save_text_file(path, file_name, str(xml_files[file_name]))
-        logging.debug(f'Wrote %s to item folder item_%s' % (file_name, element_id))
+        logging.debug('Wrote %s to item folder item_%s' % (file_name, element_id))
 
     if len(item.relations) > 0:
         save_text_file(path, 'relations', export_relations(item.relations))

--- a/pylint-rc.conf
+++ b/pylint-rc.conf
@@ -72,7 +72,7 @@ ignored-modules=
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use, and will cap the count on Windows to
 # avoid hangs.
-jobs=1
+jobs=0
 
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dspyce"
-version = "0.0.5"
+version = "0.0.6"
 authors = [
     {name="Löhden, Eike Martin"}
 ]


### PR DESCRIPTION
For faster access to the items of a DSpace instance, I added the possibility for multithreading in the `get_paginated_objects()` method.

Changes:
* Added a new parameter and variable to the RestAPI class called _workers_. Default value: 0.
* Created new method _set_workers()_ to set the number of workers for a RestAPI object after its initialization.
* Adjusted the _get_paginated_objects()_ method to use a ThreadPoolGenerator for retrieving the different pages if the class-variable _workers_ is set greater than 0. If workers will be set to -1, all available workers will be used.
* Merged small bugfix branch fixing problems with bundles metadata.