### PR TITLE
Bitstream and Bundle objects inherit DSpace Object

### DIFF
--- a/dspyce/DSpaceObject.py
+++ b/dspyce/DSpaceObject.py
@@ -111,6 +111,12 @@ class DSpaceObject:
         m = self.metadata.get(tag)
         return [v.value for v in m] if m else None
 
+    def get_first_metadata_value(self, tag: str) -> str | None:
+        """
+        Retrieve the first metadata value of a specific metadata field.
+        """
+        return self.get_metadata_values(tag)[0] if self.get_metadata_values(tag) is not None else None
+
     def add_statistic_report(self, report: dict | list[dict] | None):
         """
         Adds a new report or list of reports as a dict object to the DSpaceObject

--- a/dspyce/Item.py
+++ b/dspyce/Item.py
@@ -10,12 +10,19 @@ class Item(DSpaceObject):
     to other items, if it's an entity.
     """
     collections: list[Collection]
+    """Collections where this item belongs."""
     relations: list[Relation]
+    """The relations of the item."""
     contents: list[Bitstream]
+    """The list of bitstreams for this item."""
     bundles: list[Bundle]
+    """The list of bundles for this item."""
     in_archive: bool = True
+    """Whether an item is archived in DSpace."""
     discoverable: bool = True
+    """Whether an item is discoverable in DSpace."""
     withdrawn: bool = False
+    """Whether an item is withdrawn from DSpace."""
 
     def __init__(self, uuid: str = '', handle: str = '', name: str = '',
                  collections: Collection | list[Collection] | str = None):

--- a/dspyce/_testing/bitstreamTest.py
+++ b/dspyce/_testing/bitstreamTest.py
@@ -5,7 +5,7 @@ from dspyce.bitstreams import Bitstream
 
 class BitstreamsTest(unittest.TestCase):
     bundle: Bundle = Bundle()
-    bitstream: Bitstream = Bitstream('other', 'test-file')
+    bitstream: Bitstream = Bitstream('other', 'test-file', None, '123456789', True, 9876, 'md-123')
 
     def test_init_bundle(self):
         self.assertIsInstance(self.bundle, Bundle)
@@ -20,3 +20,14 @@ class BitstreamsTest(unittest.TestCase):
         self.assertIn(self.bitstream, self.bundle.get_bitstreams())
         self.bundle.remove_bitstream(self.bitstream)
         self.assertNotIn(self.bitstream, self.bundle.get_bitstreams())
+
+    def test_metadata(self):
+        self.bitstream.add_metadata('dc.description', 'Hello World', 'en')
+        self.assertEqual(self.bitstream.get_first_metadata_value('dc.description'), 'Hello World')
+        self.assertEqual(self.bitstream.get_description(), 'Hello World')
+        self.assertEqual(self.bitstream.get_metadata_values('dc.title')[0], 'other')
+        self.assertEqual(self.bitstream.get_dspace_object_type(), 'Bitstream')
+        self.assertEqual(self.bitstream.size_bytes, 9876)
+        self.assertEqual(self.bitstream.check_sum, 'md-123')
+        self.assertTrue(self.bitstream.primary)
+

--- a/dspyce/bitstreams/Bitstream.py
+++ b/dspyce/bitstreams/Bitstream.py
@@ -47,7 +47,8 @@ class Bitstream(DSpaceObject):
         self.size_bytes = size_bytes
         self.check_sum = check_sum
         super().__init__(uuid, '', name)
-        self.add_metadata('dc.title', name)
+        if name != '':
+            self.add_metadata('dc.title', name)
 
     def __str__(self):
         """

--- a/dspyce/bitstreams/Bitstream.py
+++ b/dspyce/bitstreams/Bitstream.py
@@ -21,8 +21,6 @@ class Bitstream(DSpaceObject):
     """The bundle where to store the file. The default is set to the variable DEFAULT_BUNDLE."""
     primary: bool
     """If the bitstream shall be the primary bitstream for the item."""
-    uuid: str
-    """A uuid if the Bitstream already exists in a DSpace-Instance."""
     size_bytes: int
     """The size of the Bitstream in bytes."""
     check_sum: str
@@ -45,7 +43,6 @@ class Bitstream(DSpaceObject):
         self.path += '/' if len(self.path) > 0 and self.path[-1] != '/' else ''
         self.permissions = []
         self.bundle = bundle
-        self.uuid = uuid
         self.primary = primary
         self.size_bytes = size_bytes
         self.check_sum = check_sum

--- a/dspyce/bitstreams/Bundle.py
+++ b/dspyce/bitstreams/Bundle.py
@@ -1,4 +1,4 @@
-from dspyce import DSpaceObject
+from dspyce.DSpaceObject import DSpaceObject
 from dspyce.bitstreams import Bitstream
 
 
@@ -21,15 +21,16 @@ class Bundle(DSpaceObject):
         :param description: A description if existing.
         :param uuid: The uuid of the bundle, if known.
         :param bitstreams: A list of bitstreams associated with this bundle.
-        :raises AttributeError: If the bundle name is not of type <str> or is empty.
+        :raises AttributeError: If the bundle name is not of type <str> or is empty and no uuid is provided.
         """
-        if not isinstance(name, str) or name.strip() == '':
+        if not isinstance(name, str) or (name.strip() == '' and uuid is None):
             raise AttributeError('You have to provide a correct bundle name expected not-empty string,'
-                                 f'but got "{name}"')
+                                 f'but got "{name}".')
         super().__init__(uuid, '', name)
-
-        self.add_metadata('dc.description', description)
-        self.add_metadata('dc.title', name)
+        if description != '':
+            self.add_metadata('dc.description', description)
+        if name != '':
+            self.add_metadata('dc.title', name)
         self.bitstreams = []
         if bitstreams is not None:
             [self.add_bitstream(b) for b in bitstreams]

--- a/dspyce/bitstreams/Bundle.py
+++ b/dspyce/bitstreams/Bundle.py
@@ -1,19 +1,14 @@
+from dspyce import DSpaceObject
 from dspyce.bitstreams import Bitstream
 
 
-class Bundle:
+class Bundle(DSpaceObject):
     """
     The class Bundle represents a bundle in the DSpace context. I can contain several bitstreams.
     """
 
-    uuid: str | None
-    """The uuid of the bundle"""
     DEFAULT_BUNDLE: str = 'ORIGINAL'
     """The default bundle name."""
-    name: str
-    """The bundle name."""
-    description: str
-    """A bundle description if existing."""
     bitstreams: list[Bitstream]
     """A list of bitstream associated with the bundle"""
 
@@ -31,9 +26,10 @@ class Bundle:
         if not isinstance(name, str) or name.strip() == '':
             raise AttributeError('You have to provide a correct bundle name expected not-empty string,'
                                  f'but got "{name}"')
-        self.name = name
-        self.uuid = uuid
-        self.description = description
+        super().__init__(uuid, '', name)
+
+        self.add_metadata('dc.description', description)
+        self.add_metadata('dc.title', name)
         self.bitstreams = []
         if bitstreams is not None:
             [self.add_bitstream(b) for b in bitstreams]
@@ -93,3 +89,15 @@ class Bundle:
         """
         for b in self.bitstreams:
             b.save_bitstream(path)
+
+    def get_description(self) -> str:
+        """
+        Returns the description of this bundle.
+        """
+        return self.get_first_metadata_value('dc.description')
+
+    def get_dspace_object_type(self) -> str:
+        """
+        Returns the DSpaceObject type, aka. "Bundle".
+        """
+        return 'Bundle'

--- a/dspyce/bitstreams/IIIFBitstream.py
+++ b/dspyce/bitstreams/IIIFBitstream.py
@@ -1,5 +1,6 @@
 import warnings
 from io import BytesIO
+
 from PIL import Image
 
 from dspyce.bitstreams import Bitstream
@@ -8,11 +9,6 @@ from dspyce.bitstreams import Bitstream
 class IIIFBitstream(Bitstream):
     """
         A class for managing iiif-specific content files in the saf-packages.
-    """
-
-    iiif: dict[str, str | int]
-    """
-        A dictionary containing the IIIF-specific information. The keys must be: 'label', 'toc', 'w', 'h'
     """
 
     def __init__(self, name: str, path: str, bundle: any = None, uuid: str = None, primary: bool = False):
@@ -26,7 +22,6 @@ class IIIFBitstream(Bitstream):
         :param primary: Primary is used to specify the primary bitstream.
         """
         super().__init__(name, path, bundle, uuid, primary)
-        self.iiif = {}
 
     def __str__(self):
         """
@@ -36,10 +31,10 @@ class IIIFBitstream(Bitstream):
         """
         export_name = super().__str__()
         if len(self.iiif.keys()) > 0:
-            export_name += (f'\tiiif-label:{self.iiif["label"]}'
-                            f'\tiiif-toc:{self.iiif["toc"]}'
-                            f'\tiiif-width:{self.iiif["w"]}'
-                            f'\tiiif-height:{self.iiif["h"]}')
+            export_name += (f'\tiiif-label:{self.get_iiif_label()}'
+                            f'\tiiif-toc:{self.get_iiif_toc()}'
+                            f'\tiiif-width:{self.get_first_metadata_value('iiif.image.width')}'
+                            f'\tiiif-height:{self.get_first_metadata_value('iiif.image.height')}')
         else:
             warnings.warn('You are about to generate information of IIIF-specific DSpace bitstream, without providing'
                           'IIIF-specific information. Are you sure, you want to do this?')
@@ -59,4 +54,29 @@ class IIIFBitstream(Bitstream):
             scale = int(width/w)
             super().file = img.reduce(scale).tobytes()
         img.close()
-        self.iiif = {'label': label, 'toc': toc, 'w': width, 'h': height}
+        self.add_metadata('iiif.label', label)
+        self.add_metadata('iiif.toc', toc)
+        self.add_metadata('iiif.image.width', str(width))
+        self.add_metadata('iiif.image.height', str(height))
+
+    def get_iiif_label(self) -> str | None:
+        """
+        Returns the label of the IIIF bitstream.
+        """
+        return self.get_first_metadata_value('iiif.label')
+
+    def get_iiif_toc(self) -> str | None:
+        """
+        Returns the toc label of the IIIF bitstream.
+        """
+        return self.get_first_metadata_value('iiif.toc')
+
+    def get_bitstream_size(self) -> tuple[float, float] | None:
+        """
+        Returns the size (width, height) of a given bitstream as a tuple of float values.
+        """
+        if (self.get_first_metadata_value('iiif.image.width') is not None and
+            self.get_first_metadata_value('iiif.image.height') is not None):
+            return (float(self.get_first_metadata_value('iiif.image.width')),
+                    float(self.get_first_metadata_value('iiif.image.height')))
+        return None

--- a/dspyce/bitstreams/IIIFBitstream.py
+++ b/dspyce/bitstreams/IIIFBitstream.py
@@ -11,7 +11,8 @@ class IIIFBitstream(Bitstream):
         A class for managing iiif-specific content files in the saf-packages.
     """
 
-    def __init__(self, name: str, path: str, bundle: any = None, uuid: str = None, primary: bool = False):
+    def __init__(self, name: str, path: str, bundle: any = None, uuid: str = None, primary: bool = False,
+                 size_bytes: int = None, check_sum: str = None):
         """
         Creates a new IIIF-Bitstream object.
 
@@ -20,8 +21,10 @@ class IIIFBitstream(Bitstream):
         :param bundle: The bundle, where the bitstream should be placed in. The default is ORIGINAL.
         :param uuid: The uuid of the bitstream if existing.
         :param primary: Primary is used to specify the primary bitstream.
+        :param size_bytes: The size of the bitstream in bytes.
+        :param check_sum: The checksum of the bitstream.
         """
-        super().__init__(name, path, bundle, uuid, primary)
+        super().__init__(name, path, bundle, uuid, primary, size_bytes, check_sum)
 
     def __str__(self):
         """

--- a/dspyce/rest/RestAPI.py
+++ b/dspyce/rest/RestAPI.py
@@ -399,15 +399,7 @@ class RestAPI:
             logging.critical('Could not add object, authentication required!')
             raise ConnectionRefusedError('Authentication needed.')
         add_url = f'{self.api_endpoint}/core/bundles/{bundle.uuid}/bitstreams'
-        obj_json = {'name': bitstream.file_name, 'metadata': {'dc.title': [{'value': bitstream.file_name}],
-                                                              'dc.description': [{'value': bitstream.description}]},
-                    'bundleName': bundle.name}
-        if isinstance(bitstream, IIIFBitstream):
-            bitstream: IIIFBitstream
-            obj_json['metadata']['iiif.label'] = [{'value': bitstream.iiif['label']}]
-            obj_json['metadata']['iiif.toc'] = [{'value': bitstream.iiif['toc']}]
-            obj_json['metadata']['iiif.image.width'] = [{'value': bitstream.iiif['w']}]
-            obj_json['metadata']['iiif.image.height'] = [{'value': bitstream.iiif['h']}]
+        obj_json = bitstream.to_dict()
         logging.debug(f'Adding bitstream: {obj_json}')
         bitstream_file = bitstream.get_bitstream_file()
         data_file = {'file': (bitstream.file_name, bitstream_file)} if bitstream_file is not None else None

--- a/dspyce/rest/RestAPI.py
+++ b/dspyce/rest/RestAPI.py
@@ -656,8 +656,8 @@ class RestAPI:
         :return: The list of Bundle objects.
         """
         bundle_json = self.get_paginated_objects(f'/core/items/{item_uuid}/bundles', 'bundles')
-        return [Bundle(b["name"],
-                       b['dc.description'][0]['value'] if 'dc.description' in b["metadata"].keys() else '',
+        return [Bundle(b['name'],
+                       b['metadata']['dc.description'][0]['value'] if 'dc.description' in b['metadata'].keys() else '',
                        b['uuid']) for b in bundle_json]
 
     def get_relations_by_type(self, entity_type: str) -> list[Relation]:

--- a/dspyce/rest/RestAPI.py
+++ b/dspyce/rest/RestAPI.py
@@ -44,10 +44,12 @@ def json_to_object(json_content: dict) -> DSpaceObject | Item | Community | Coll
                 obj.withdrawn = str(json_content['withdrawn']).lower() == 'true'
         case 'bitstream':
             href = _links['content'].get('href') if 'content' in _links else None
-            obj = Bitstream(name, href, None, uuid, False, json_content.get('sizeBytes'),
+            obj = Bitstream('', href, None, uuid, False, json_content.get('sizeBytes'),
                             json_content.get('checkSum').get('value'))
+            obj.name = name # Set here to avoid duplicate 'dc.title'
         case 'bundle':
-            obj = Bundle(name, '', uuid)
+            obj = Bundle('', '', uuid)
+            obj.name = name # Set here to avoid duplicate 'dc.title'
         case _:
             obj = DSpaceObject(uuid, handle, name)
     for m in metadata.keys():

--- a/dspyce/rest/RestAPI.py
+++ b/dspyce/rest/RestAPI.py
@@ -36,10 +36,18 @@ def json_to_object(json_content: dict) -> DSpaceObject | Item | Community | Coll
             obj = Collection(uuid, handle=handle, name=name)
         case 'item':
             obj = Item(uuid, handle=handle, name=name)
+            if 'inArchive' in json_content.keys():
+                obj.inArchive = str(json_content['inArchive']).lower() == 'true'
+            if 'discoverable' in json_content.keys():
+                obj.discoverable = str(json_content['discoverable']).lower() == 'true'
+            if 'withdrawn' in json_content.keys():
+                obj.withdrawn = str(json_content['withdrawn']).lower() == 'true'
         case 'bitstream':
             href = _links['content'].get('href') if 'content' in _links else None
             obj = Bitstream(name, href, None, uuid, False, json_content.get('sizeBytes'),
                             json_content.get('checkSum').get('value'))
+        case 'bundle':
+            obj = Bundle(name, '', uuid)
         case _:
             obj = DSpaceObject(uuid, handle, name)
     for m in metadata.keys():


### PR DESCRIPTION
Updated Bitstream and Bundle classes to match DSpaceObject as a parent Class, thus simplifying the representation in the RestAPI class. 