### PR TITLE
Add classes for MetadataSchema and MetadataField objects

### DIFF
--- a/dspyce/_testing/restTest.py
+++ b/dspyce/_testing/restTest.py
@@ -1,9 +1,9 @@
 import copy
-import logging
+import requests
 import unittest
 
 from dspyce.bitstreams.models import Bundle, Bitstream
-from dspyce.rest.exceptions import RestObjectNotFoundError
+from dspyce.rest.exceptions import RestObjectNotFoundError, InvalidMetadataException
 from dspyce.rest.models import RestAPI
 from dspyce.models import Community, Collection, Item
 
@@ -94,6 +94,12 @@ class RestTest(unittest.TestCase):
         item.move_item(rest, mapped_collection)
         self.assertEqual(mapped_collection, item.get_owning_collection())
         self.assertEqual(item, mapped_collection.get_items(rest)[0])
+        error_item = Item(collections=[collection])
+        error_item.add_metadata('xy.ab.cd', 'Invalid field!', 'NAN')
+        self.assertRaises(InvalidMetadataException, error_item.to_rest, rest)
+        item.track_updates()
+        item.add_metadata('xy.ab.cd', 'Invalid field!', 'NAN')
+        self.assertRaises(InvalidMetadataException, item.update_metadata_rest, rest, True)
         community.delete(rest, True)
 
     def test_metadata(self):

--- a/dspyce/_testing/restTest.py
+++ b/dspyce/_testing/restTest.py
@@ -8,7 +8,7 @@ from dspyce.models import Community, Collection, Item
 
 
 class RestTest(unittest.TestCase):
-    rest_url = 'http://localhost:8080/server/api'
+    rest_url = 'https://demo.dspace.org/server/api'
     rest_user = 'dspacedemo+admin@gmail.com'
     rest_pwd = 'dspace'
 
@@ -32,7 +32,7 @@ class RestTest(unittest.TestCase):
         collection.add_metadata('dc.title', 'Test Collection')
         item = Item(collections=collection)
         item.add_metadata('dc.title', 'Test Item')
-        item.add_content('collections', './test_data/saf_item')
+        item.add_content('collections', 'https://demo.dspace.org/server/api')
         community.to_rest(rest)
         collection.to_rest(rest)
         item.to_rest(rest)
@@ -84,7 +84,7 @@ class RestTest(unittest.TestCase):
         item.add_to_mapped_collections(rest, [mapped_collection])
         self.assertEqual(item, mapped_collection.get_items(rest)[0])
         bundle = Bundle('TEXT', 'Bundle containing text items.')
-        bundle.add_bitstream(Bitstream('handle', './test_data/saf_item', bundle, primary=True))
+        bundle.add_bitstream(Bitstream('handle', 'https://demo.dspace.org/server/api', bundle, primary=True))
         item.add_bundle(bundle)
         item.add_bundles_to_rest(rest)
         self.assertNotEqual('', item.get_bundle('TEXT').uuid)

--- a/dspyce/_testing/restTest.py
+++ b/dspyce/_testing/restTest.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import unittest
 
 from dspyce.bitstreams.models import Bundle, Bitstream
@@ -176,6 +177,17 @@ class RestTest(unittest.TestCase):
         self.assertGreater(len(schemas), 0)
         dc_schema = MetadataSchema.get_schema_from_rest(rest, 1)
         self.assertEqual(dc_schema.prefix, 'dc')
+
+    def test_metadata_fields(self):
+        """
+        Test metadata-fields operations with the restAPI.
+        """
+        rest = self.get_rest()
+        from dspyce.metadata import MetadataField
+        field = MetadataField.get_metadata_field_from_rest(rest, 1)
+        self.assertIsNotNone(field.element)
+        self.assertIsNotNone(field.schema)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/dspyce/_testing/restTest.py
+++ b/dspyce/_testing/restTest.py
@@ -166,6 +166,16 @@ class RestTest(unittest.TestCase):
         self.assertListEqual(['Großartiger Testbereich'], community.get_metadata_values('dc.title'))
         community.delete(rest, True)
 
+    def test_metadata_schemas(self):
+        """
+        Test metadata-schema operations with the restAPI.
+        """
+        rest = self.get_rest()
+        from dspyce.metadata import MetadataSchema
+        schemas = MetadataSchema.get_schemas_from_rest(rest)
+        self.assertGreater(len(schemas), 0)
+        dc_schema = MetadataSchema.get_schema_from_rest(rest, 1)
+        self.assertEqual(dc_schema.prefix, 'dc')
 
 if __name__ == '__main__':
     unittest.main()

--- a/dspyce/_testing/restTest.py
+++ b/dspyce/_testing/restTest.py
@@ -187,6 +187,8 @@ class RestTest(unittest.TestCase):
         field = MetadataField.get_metadata_field_from_rest(rest, 1)
         self.assertIsNotNone(field.element)
         self.assertIsNotNone(field.schema)
+        fields = MetadataField.search_in_rest(rest, 'dc', 'contributor', 'author')
+        self.assertEqual(len(fields), 1)
 
 
 if __name__ == '__main__':

--- a/dspyce/metadata/__init__.py
+++ b/dspyce/metadata/__init__.py
@@ -1,2 +1,3 @@
 from dspyce.metadata.models import MetaData
 from dspyce.metadata.models import MetaDataValue
+from dspyce.metadata.models import MetadataSchema

--- a/dspyce/metadata/__init__.py
+++ b/dspyce/metadata/__init__.py
@@ -1,3 +1,4 @@
 from dspyce.metadata.models import MetaData
 from dspyce.metadata.models import MetaDataValue
 from dspyce.metadata.models import MetadataSchema
+from dspyce.metadata.models import MetadataField

--- a/dspyce/metadata/models.py
+++ b/dspyce/metadata/models.py
@@ -202,3 +202,67 @@ class MetadataSchema:
         schema_obj = MetadataSchema(obj['prefix'], obj['namespace'], obj['id'])
         logging.debug('Retrieved metadataschema with prefix.', schema_obj.prefix)
         return schema_obj
+
+class MetadataField:
+    id: int
+    """The id of the metadata field."""
+    schema: MetadataSchema
+    """The MetadataSchema of the metadata field."""
+    element: str
+    """The name of the metadata field."""
+    qualifier: str | None
+    """The qualifier of the metadata field."""
+    scope_note: str | None
+    """The scope note of the metadata field."""
+
+    def __init__(self, schema: MetadataSchema, element: str, qualifier: str = None, scope_note: str = None, id: int = None):
+        """
+        Creates a new metadata field object.
+        :param element: The name of the metadata field.
+        :param qualifier: The qualifier of the metadata field.
+        :param scope_note: The scope note of the metadata field.
+        :param id: The id of the metadata field, optional.
+        """
+        self.schema = schema
+        self.element = element
+        self.qualifier = qualifier
+        self.scope_note = scope_note
+        self.id = id
+
+    def update_schema_from_rest(self, rest_api):
+        """
+        Updates the schema information from the given rest API object based on the ID of the current metadata field.
+        :param rest_api: The rest API object to use.
+        """
+        url = f'/core/metadatafields/{id}/schema'
+        obj = rest_api.get_api(url)
+        self.schema = MetadataSchema(obj['prefix'], obj['namespace'], obj['id'])
+
+    @staticmethod
+    def get_metadata_field_from_rest(rest_api, id: int):
+        """
+        Retrieves a specific metadata field from the given rest API.
+        :param rest_api: The rest API object to use.
+        :param id: The id of the metadata field to retrieve.
+        :return: The new MetadataField object.
+        """
+        url = f'/core/metadatafields/{id}'
+        obj = rest_api.get_api(url)
+        if obj is None:
+            logging.error('Could not retrieve metadata field with id %i.', id)
+            return None
+        schema_obj = None
+        if obj.get('_embedded') is not None and obj['_embedded'].get('schema') is not None:
+            schema_obj = MetadataSchema(obj['_embedded']['schema']['prefix'],
+                                        obj['_embedded']['schema']['namespace'],
+                                        obj['_embedded']['schema']['id'])
+        field_obj = MetadataField(schema_obj, obj['element'], obj.get('qualifier'), obj.get('scope_note'), obj['id'])
+        if schema_obj is None:
+            field_obj.update_schema_from_rest(rest_api)
+        logging.debug('Retrieved metadata field "%s".', str(field_obj))
+        return field_obj
+
+    def __str__(self):
+        """Creates string representation of the current MetadataField object."""
+        return f'{self.schema.prefix}.{self.element}' + (f'.{self.qualifier}' if self.qualifier is not None else '')
+

--- a/dspyce/metadata/models.py
+++ b/dspyce/metadata/models.py
@@ -1,3 +1,4 @@
+import logging
 import re
 
 
@@ -148,3 +149,56 @@ class MetaData(dict):
         Returns the metadata including all values as a rest-compatible dictionary.
         """
         return {k: list(map(lambda x: dict(x), self.get(k))) for k in self.keys()}
+
+
+class MetadataSchema:
+    id: int
+    """The ID of the metadata schema."""
+    prefix: str
+    """The prefix of the metadata schema, aka dc, dc-terms, ..."""
+    namespace: str
+    """An url to the namespace of the schema."""
+
+    def __init__(self, prefix: str, namespace: str, id: int = None):
+        """
+        Creates a new object of the  MetadataSchema class.
+        :param prefix: The prefix of the schema.
+        :param namespace: The namespace of the schema.
+        :param id: The id of the schema, optional.
+        """
+        self.prefix = prefix
+        self.namespace = namespace
+        self.id = id
+
+    @staticmethod
+    def get_schemas_from_rest(rest_api):
+        """
+        Retrieves a metadata schema by its id from the given rest API.
+        :param rest_api: The rest API object to use.
+        """
+        """
+        Retrieves all sub communities from the current community.
+        :param rest_api: The rest API object to use.
+        :param in_place: If True, the returned object will be placed into the current community.
+        :return: A list of sub communities if in_place i False, None otherwise.
+        """
+        url = f'/core/metadataschemas'
+        objs = rest_api.get_paginated_objects(url, 'metadataschemas')
+        logging.debug('Retrieved %i metadataschemas.', len(objs))
+        return [MetadataSchema(i['prefix'], i['namespace'], i['id']) for i in objs]
+
+    @staticmethod
+    def get_schema_from_rest(rest_api, id: int):
+        """
+        Retrieves a metadata schema by its id from the given rest API.
+        :param rest_api: The rest API object to use.
+        :param id: The id of the schema to retrieve.
+        """
+        url = f'/core/metadataschemas/{id}'
+        obj = rest_api.get_api(url)
+        if obj is None:
+            logging.error('Could not retrieve metadata schema with id %i.', id)
+            return None
+        schema_obj = MetadataSchema(obj['prefix'], obj['namespace'], obj['id'])
+        logging.debug('Retrieved metadataschema with prefix.', schema_obj.prefix)
+        return schema_obj

--- a/dspyce/metadata/models.py
+++ b/dspyce/metadata/models.py
@@ -204,6 +204,7 @@ class MetadataSchema:
         return schema_obj
 
 class MetadataField:
+    """A DSpace Metadata Field."""
     id: int
     """The id of the metadata field."""
     schema: MetadataSchema
@@ -239,6 +240,21 @@ class MetadataField:
         self.schema = MetadataSchema(obj['prefix'], obj['namespace'], obj['id'])
 
     @staticmethod
+    def _get_from_json(json_obj: dict):
+        """
+        Creates a MetadataField object from the given json object.
+        """
+        schema_obj = None
+        if json_obj.get('_embedded') is not None and json_obj['_embedded'].get('schema') is not None:
+            schema_obj = MetadataSchema(json_obj['_embedded']['schema']['prefix'],
+                                        json_obj['_embedded']['schema']['namespace'],
+                                        json_obj['_embedded']['schema']['id'])
+        field_obj = MetadataField(schema_obj, json_obj['element'], json_obj.get('qualifier'),
+                                  json_obj.get('scope_note'), json_obj['id'])
+        return field_obj
+
+
+    @staticmethod
     def get_metadata_field_from_rest(rest_api, id: int):
         """
         Retrieves a specific metadata field from the given rest API.
@@ -251,16 +267,38 @@ class MetadataField:
         if obj is None:
             logging.error('Could not retrieve metadata field with id %i.', id)
             return None
-        schema_obj = None
-        if obj.get('_embedded') is not None and obj['_embedded'].get('schema') is not None:
-            schema_obj = MetadataSchema(obj['_embedded']['schema']['prefix'],
-                                        obj['_embedded']['schema']['namespace'],
-                                        obj['_embedded']['schema']['id'])
-        field_obj = MetadataField(schema_obj, obj['element'], obj.get('qualifier'), obj.get('scope_note'), obj['id'])
-        if schema_obj is None:
+        field_obj = MetadataField._get_from_json(obj)
+        if field_obj.schema is None:
             field_obj.update_schema_from_rest(rest_api)
         logging.debug('Retrieved metadata field "%s".', str(field_obj))
         return field_obj
+
+    @staticmethod
+    def search_in_rest(rest_api, schema: str, element: str = None, qualifier: str = None):
+        """
+        Search a field object by schema, element, qualifier in the given rest API.
+        :param rest_api: The rest API object to use.
+        :param schema: The schema to search for.
+        :param element: The element to search for.
+        :param qualifier: The qualifier to search for.
+        """
+        url = '/core/metadatafields/search/byFieldName'
+        from dspyce.rest import RestAPI
+        rest_api: RestAPI
+        params = {'schema': schema}
+        if element is not None:
+            params['element'] = element
+        if qualifier is not None:
+            params['qualifier'] = qualifier
+        objs = rest_api.get_paginated_objects(url, 'metadatafields', params)
+        field_objs = []
+        for i in objs:
+            field_obj = MetadataField._get_from_json(i)
+            if field_obj.schema is None:
+                field_obj.update_schema_from_rest(rest_api)
+            field_objs.append(field_obj)
+        return field_objs
+
 
     def __str__(self):
         """Creates string representation of the current MetadataField object."""

--- a/dspyce/models.py
+++ b/dspyce/models.py
@@ -2,6 +2,8 @@ import logging
 from json import JSONDecodeError
 
 import requests
+
+from dspyce.metadata import MetadataField, MetadataSchema
 from dspyce.metadata.models import MetaData, MetaDataValue
 
 
@@ -113,8 +115,10 @@ class DSpaceObject:
         :param rest_api: The rest API object to use.
         :raises ConnectionRefusedError: If the rest API object did not provide authentication information.
         :raises TypeError: If the current DSpaceObject type does not exist.
-        :raises ValueError: If the curren DSpaceObject already has a uuid.
+        :raises ValueError: If the curren DSpaceObject already has an uuid.
+        :raises InvalidMetadataException: If the current DSpaceObject does not contain correct metadata.
         """
+        from dspyce.rest.exceptions import InvalidMetadataException
         from dspyce.rest.functions import json_to_object
         if not rest_api.authenticated:
             logging.critical('Could not add object, authentication required!')
@@ -123,6 +127,7 @@ class DSpaceObject:
             raise ValueError(f'The current {self.get_dspace_object_type()} already has an uuid. It might exist already '
                              'in the DSpace repository')
         params = {}
+        add_url = ''
         match self.get_dspace_object_type():
             case 'Item':
                 self: Item
@@ -141,7 +146,28 @@ class DSpaceObject:
                 params = {'parent': self.community.uuid}
             case _:
                 raise TypeError(f'Object type {self.get_dspace_object_type()} is not allowed as a parameter!')
-        obj_json = rest_api.post_api(add_url, data=self.to_dict(), params=params)
+        try:
+            obj_json = rest_api.post_api(add_url, data=self.to_dict(), params=params)
+        except requests.exceptions.RequestException as e:
+            status_code = e.response.status_code
+            logging.error('Could not post object. Got status code %i.' % status_code)
+
+            if status_code == 400:
+                metadata_fields = [m.split('.') for m in self.metadata.keys()]
+                invalid_fields = []
+                for field in metadata_fields:
+                    schema, element, qualifier = field if len(field) == 3 else (field[0], field[1], None)
+                    try:
+                        n = len(MetadataField.search_in_rest(rest_api, schema, element, qualifier))
+                    except KeyError:
+                        n = 0
+                    if n == 0:
+                        error_note = 'The metadata field "%s" does not exist in the given restAPI.' % '.'.join(field)
+                        logging.error(error_note)
+                        invalid_fields.append(MetadataField(MetadataSchema(schema, '', None), element, qualifier))
+                e = InvalidMetadataException()
+                e.invalid_metadata_fields = invalid_fields
+            raise e
         obj = json_to_object(obj_json)
         self.uuid = obj.uuid
         self.handle = obj.handle

--- a/dspyce/rest/exceptions.py
+++ b/dspyce/rest/exceptions.py
@@ -1,3 +1,7 @@
+class InvalidMetadataException(AttributeError):
+    from dspyce.metadata import MetadataField
+    invalid_metadata_fields: list[MetadataField]
+
 class RestObjectNotFoundError(FileNotFoundError):
     """ DSpaceObject not found. """
     def __init__(self, *args, **kwargs):

--- a/dspyce/rest/models.py
+++ b/dspyce/rest/models.py
@@ -222,7 +222,8 @@ class RestAPI:
         logging.error(f'Statuscode: {resp.status_code}')
         raise requests.exceptions.RequestException(f'\nStatuscode: {resp.status_code}\n'
                                                    f'Could not post content: \n\t{data}'
-                                                   f'\nWith params: {params}\nOn endpoint:\n\t{url}')
+                                                   f'\nWith params: {params}\nOn endpoint:\n\t{url}',
+                                                 response=resp)
 
     def patch_api(self, url: str, json_data: list, params: dict = None) -> dict | None:
         """
@@ -256,7 +257,8 @@ class RestAPI:
         logging.error(f'Statuscode: {resp.status_code}')
         raise requests.exceptions.RequestException(f'\nStatuscode: {resp.status_code}\n'
                                                    f'Could not put content: \n\t{json_data}'
-                                                   f'\nWith params: {params}\nOn endpoint:\n\t{url}')
+                                                   f'\nWith params: {params}\nOn endpoint:\n\t{url}',
+                                                   response = resp)
 
     def put_api(self, url: str, data: list | dict | str, params: dict = None, content_type: str = None) -> None:
         """
@@ -570,6 +572,8 @@ class RestAPI:
         :return: The updated DSpace object.
         :raises ValueError: If a not existing objectType is used.
         """
+        from dspyce.metadata import MetadataField, MetadataSchema
+        from dspyce.rest.exceptions import InvalidMetadataException
 
         if isinstance(metadata, self.MetaData):
             metadata = {key: [dict(v) for v in metadata[key]] for key in metadata.keys()}
@@ -577,8 +581,26 @@ class RestAPI:
             # Checks if there is only one metadata key with only one value.
             if len(metadata.keys()) == 1 and position_end and len(metadata[list(metadata.keys())[0]]) == 1:
                 metadata = {list(metadata.keys())[0]: metadata[list(metadata.keys())[0]][0]}
-        return self.update_metadata(metadata, object_uuid, obj_type, 'add',
-                                    position='-' if position_end else -1)
+        try:
+            return self.update_metadata(metadata, object_uuid, obj_type, 'add',
+                                        position='-' if position_end else -1)
+        except requests.exceptions.RequestException as e:
+            if e.response.status_code == 415:
+                metadata_fields = [m.split('.') for m in metadata.keys()]
+                invalid_fields = []
+                for field in metadata_fields:
+                    schema, element, qualifier = field if len(field) == 3 else (field[0], field[1], None)
+                    try:
+                        n = len(MetadataField.search_in_rest(self, schema, element, qualifier))
+                    except KeyError:
+                        n = 0
+                    if n == 0:
+                        error_note = 'The metadata field "%s" does not exist in the given restAPI.' % '.'.join(field)
+                        logging.error(error_note)
+                        invalid_fields.append(MetadataField(MetadataSchema(schema, '', None), element, qualifier))
+                e = InvalidMetadataException()
+                e.invalid_metadata_fields = invalid_fields
+            raise e
 
     def replace_metadata(self, metadata: MetaData | dict[str, list[dict] | dict], object_uuid: str,
                          obj_type: str, position: int = -1) -> DSpaceObject:


### PR DESCRIPTION
Solves #15

## Changes in this PR
* Created new classes MetadataSchema, MetadataField
* New Exception class InvalidMetadataException
* Added check at the creation of new item:* 
  * if the returned status code equals 400, the restAPI will be checked for existing metadata fields. If a field does not exist, it will be returned in the exception 
* Added check at the creation of new metadata:
  * if the returned status code equals 415, the restAPI will be checked for existing metadata fields. If a field does not exist, it will be returned in the exception 