### PR TITLE
fix(rest): fix reauthentication flow and set keep_session_alive as daemon thread

### DIFF
--- a/dspyce/rest/models.py
+++ b/dspyce/rest/models.py
@@ -47,8 +47,8 @@ class RestAPI:
     """The password of the user communicating with the endpoint."""
     session: requests.sessions.Session
     """The active session."""
-    session_refresh_timeout: int = (60 * 28)
-    """The session refresh timeout. The time after the session is refreshed. Default is 28 minutes."""
+    session_refresh_timeout: int
+    """The session refresh timeout. The time after the session is refreshed."""
     authenticated: bool = False
     """Provides information about the authentication status."""
     dspace_version: str
@@ -57,7 +57,7 @@ class RestAPI:
     """The number of worker threads used by the ThreadPoolExecutor."""
 
     def __init__(self, api_endpoint: str, username: str = None, password: str = None,
-                 log_level: int | str = logging.INFO, log_file: str = None, workers: int = 0):
+                 log_level: int | str = logging.INFO, log_file: str = None, workers: int = 0, session_refresh_timeout: int = (60 * 28)):
         """
         Creates a new object of the RestAPI class using
 
@@ -70,6 +70,8 @@ class RestAPI:
             console.
         :param workers: The number of worker threads to use, if this value equals 0 no ThreadPoolExecutor is used.
             Default is 0.
+        :param session_refresh_timeout: The time after the session is refreshed. Default is 28 minutes, which is 2
+            minutes before the default session timeout of 30 minutes in DSpace. Default is 60*28
         """
         log_level_types = {'DEBUG': logging.DEBUG, 'INFO': logging.INFO, 'WARNING': logging.WARNING,
                            'ERROR': logging.ERROR, 'CRITICAL': logging.CRITICAL}
@@ -89,6 +91,7 @@ class RestAPI:
             self.dspace_version = endpoint_info['dspaceVersion']
         self.username = username
         self.password = password
+        self.session_refresh_timeout = session_refresh_timeout
         self.req_headers = {'Content-type': 'application/json', 'User-Agent': 'dspyce/0.2'}
         if username is not None and password is not None:
             self.authenticated = self.authenticate_api()

--- a/dspyce/rest/models.py
+++ b/dspyce/rest/models.py
@@ -155,8 +155,9 @@ class RestAPI:
         auth_url = f'{self.api_endpoint}/authn/login'
         if refresh_current_session:
             logging.info(f'Trying to refresh the current session against the REST-API "{self.api_endpoint}"')
+            pre_req = self.session.post(auth_url)
+            self.update_csrf_token(pre_req)
             req = self.session.post(auth_url)
-            self.update_csrf_token(req)
         else:
             logging.info(f'Trying to authenticate against the REST-API "{self.api_endpoint}", with user {self.username}')
             req = self.session.post(auth_url)

--- a/dspyce/rest/models.py
+++ b/dspyce/rest/models.py
@@ -173,6 +173,7 @@ class RestAPI:
                 logging.info(f'The authentication as "{self.username}" was successfully')
                 # basic way to wait "session_timeout" seconds in a thread and then refresh login token
                 keep_session_alive = threading.Timer(self.session_refresh_timeout, self.keep_session_alive)
+                keep_session_alive.daemon = True
                 keep_session_alive.start()
                 return True
         except requests.exceptions.JSONDecodeError as e:


### PR DESCRIPTION
## Summary
This PR addresses three main issues within `dspyce/rest/models.py`: a broken reauthentication flow due to incorrect CSRF token handling, a hanging process caused by a non-daemon session thread, and an unintuitive/error-prone configuration of the `session_refresh_timeout` class variable.

## Changes
1. Fix Reauthentication Flow (CSRF & Bearer Token)

    **Issue**: Reauthentication within the `keep_session_alive` thread fails because the CSRF token is not updated in the correct order. As a result, the `Authorization` header receives a `None` value for the new Bearer token, causing the session to expire permanently.

    **Fix**: Updated the logic to first refresh the CSRF token via an initial `POST` request, followed by a second `POST` request to successfully retrieve and apply the new Bearer token.

2. Convert `keep_session_alive` Thread to Daemon Thread

    **Issue**: The `keep_session_alive thread` was running as a non-daemon thread. This prevents the main Python process from exiting when the main thread finishes, leading to an infinite loop of re-logins in the terminal until manually interrupted via `Ctrl+C`.

    **Fix**: Configured the thread as a daemon by setting `keep_session_alive.daemon = True`. It will now automatically terminate when the main thread exits. Since this thread only tracks time and manages the refresh interval, abrupt termination is safe and preferred.

3. Refactor `session_refresh_timeout` from Class to Instance Variable

    **Issue**: Defining `session_refresh_timeout` as a class variable is unintuitive for users (as IDEs often don't autocomplete it easily for instances). Furthermore, it is error-prone because users must modify the class variable before object instantiation for the timer to pick it up correctly.

    **Fix**: Moved `session_refresh_timeout` into the `__init__` constructor as an instance variable with a default value (30 minutes).

    **Benefit**: Users can now pass the timeout directly during initialization alongside other parameters. The responsibility for correct timing setup is handled internally by _dspyce_, reducing unexpected behavior.

## Checklist

- [x] Bugfixes tested locally
- [x] Order of token requests corrected
- [x] Main process exits cleanly without hanging